### PR TITLE
バージョン差異によるテストエラーを修正

### DIFF
--- a/test/output.ts
+++ b/test/output.ts
@@ -46,7 +46,11 @@ describe('output', () => {
 			logger.info(Symbol('walk8243'));
 			checkBasicOutFormat(levels.INFO, 'MidSummer', 'Symbol\\(walk8243\\)');
 			logger.info(function() { return 'walk8243'; });
-			checkBasicOutFormat(levels.INFO, 'MidSummer', '\\[Function \\(anonymous\\)\\]');
+			if(process.version.startsWith('v10.') || process.version.startsWith('v12.')) {
+				checkBasicOutFormat(levels.INFO, 'MidSummer', '\\[Function\\]');
+			} else {
+				checkBasicOutFormat(levels.INFO, 'MidSummer', '\\[Function \\(anonymous\\)\\]');
+			}
 			logger.info(function test() { return 'walk8243'; });
 			checkBasicOutFormat(levels.INFO, 'MidSummer', '\\[Function: test\\]');
 			logger.info(new Error('walk8243'));
@@ -121,7 +125,11 @@ describe('output', () => {
 			logger.info(Symbol('walk8243'));
 			checkColorOutFormat(levels.INFO, 'debug', 'Symbol\\(walk8243\\)');
 			logger.info(function() { return 'walk8243'; });
-			checkColorOutFormat(levels.INFO, 'debug', '\\[Function \\(anonymous\\)\\]');
+			if(process.version.startsWith('v10.') || process.version.startsWith('v12.')) {
+				checkColorOutFormat(levels.INFO, 'debug', '\\[Function\\]');
+			} else {
+				checkColorOutFormat(levels.INFO, 'debug', '\\[Function \\(anonymous\\)\\]');
+			}
 			logger.info(function test() { return 'walk8243'; });
 			checkColorOutFormat(levels.INFO, 'debug', '\\[Function: test\\]');
 			logger.info(new Error('walk8243'));
@@ -346,7 +354,11 @@ describe('output', () => {
 			logger.info(Symbol('walk8243'));
 			checkColorOutFormat(levels.INFO, 'color', 'Symbol\\(walk8243\\)');
 			logger.info(function() { return 'walk8243'; });
-			checkColorOutFormat(levels.INFO, 'color', '\\[Function \\(anonymous\\)\\]');
+			if(process.version.startsWith('v10.') || process.version.startsWith('v12.')) {
+				checkColorOutFormat(levels.INFO, 'color', '\\[Function\\]');
+			} else {
+				checkColorOutFormat(levels.INFO, 'color', '\\[Function \\(anonymous\\)\\]');
+			}
 			logger.info(function test() { return 'walk8243'; });
 			checkColorOutFormat(levels.INFO, 'color', '\\[Function: test\\]');
 			logger.info(new Error('walk8243'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "ES2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2018"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
# 概要

無名関数をログに出したとき、デフォルトで出力されるものが、 `v12` 以前と `v14` 以降で異なる。
その差異を許容する。